### PR TITLE
Fix mapping of item_id in rpc_sub

### DIFF
--- a/lib/poke-api/protos/rpc_sub.proto
+++ b/lib/poke-api/protos/rpc_sub.proto
@@ -108,7 +108,7 @@ message Pokemon {
 }
 
 message Item {
-  RpcEnum.ItemType item = 1;
+  RpcEnum.ItemId item = 1;
   int32 count = 2;
   bool unseen = 3;
 }

--- a/lib/poke-api/protos/rpc_sub.rb
+++ b/lib/poke-api/protos/rpc_sub.rb
@@ -96,7 +96,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :from_fort, :int32, 31
   end
   add_message "RpcSub.Item" do
-    optional :item, :enum, 1, "RpcEnum.ItemType"
+    optional :item, :enum, 1, "RpcEnum.ItemId"
     optional :count, :int32, 2
     optional :unseen, :bool, 3
   end


### PR DESCRIPTION
When comparing the app to the api values, I found that most items were not mapped to symbols, and the ones that were getting mapped are showing incorrect values.
Found out that it was incorrectly mapping to categories where it should be mapping to ids.
Not sure if this is a complete fix, but it fixed the issue for me.
