### PR TITLE
Update GPSOAuth gem version to 0.1.2

### DIFF
--- a/poke-api.gemspec
+++ b/poke-api.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'httpclient', '2.8.0'
   spec.add_runtime_dependency 'geocoder', '1.3.7'
   spec.add_runtime_dependency 'google-protobuf', '~> 3.0.0.alpha'
-  spec.add_runtime_dependency 'gpsoauth-rb', '0.1.1'
+  spec.add_runtime_dependency 'gpsoauth-rb', '0.1.2'
 end


### PR DESCRIPTION
This allows for backwards compatibility with older Ruby versions.
