### PR TITLE
Use upcase instead of upcase! to fix a few bugs

### DIFF
--- a/lib/poke-api/client.rb
+++ b/lib/poke-api/client.rb
@@ -14,6 +14,7 @@ module Poke
       end
 
       def login(username, password, provider)
+        provider = provider.upcase
         raise Errors::InvalidProvider.new(provider) unless ['PTC', 'GOOGLE'].include?(provider.upcase!)
         logger.info "[+] Logging in user: #{username}"
 


### PR DESCRIPTION
This is an interesting error. If I run

```
provider = 'google'
@api.login(user, pass, provider)
@api.login(user, pass, provider)
```

The second login will throw a InvalidProvider error because the `upcase!` method is used directly on the variable sent to it. This changes the `provider`  variable that is sent as a parameter as well. So provider is then all caps, and when using `upcase!`  for the second time, it returns nil because no changes were made. This is intentional (ruby-doc.org).

> Upcases the contents of str, returning nil if no changes were made. Note: case replacement is effective only in ASCII region.

you could use `provider = provider.dup` but then it will still fail if I pass in `PTC` or `GOOGLE` because again, `upcase!` would make no changes. using `upcase` will always return the string even if no change it made.
