### PR TITLE
store_lat_lng function to avoid Geocoder usage

### DIFF
--- a/lib/poke-api/client.rb
+++ b/lib/poke-api/client.rb
@@ -54,7 +54,7 @@ module Poke
       end
       
       def store_lat_lng(lat, lng)
-        logger.info "[+] Lat/Long: #{pos.latitude}, #{pos.longitude}"
+        logger.info "[+] Lat/Long: #{lat}, #{lng}"
         @lat, @lng = lat, lng
       end
 

--- a/lib/poke-api/client.rb
+++ b/lib/poke-api/client.rb
@@ -52,6 +52,11 @@ module Poke
         logger.info "[+] Lat/Long: #{pos.latitude}, #{pos.longitude}"
         @lat, @lng = pos.latitude, pos.longitude
       end
+      
+      def store_lat_lng(lat, lng)
+        logger.info "[+] Lat/Long: #{pos.latitude}, #{pos.longitude}"
+        @lat, @lng = lat, lng
+      end
 
       def inspect
         "#<#{self.class.name} @auth=#{@auth} @reqs=#{@reqs} " \


### PR DESCRIPTION
If we already have Lat Lng value for the user location, we don't need to create Geocoder request.
This method will prevent people from getting rate limited by Geocoder
