### PR TITLE
Fix recursive login fail

### DIFF
--- a/lib/poke-api/client.rb
+++ b/lib/poke-api/client.rb
@@ -76,7 +76,7 @@ module Poke
 
         resp = call.response
 
-        if !resp[:api_url] || resp[:api_url].empty?
+        if resp[:api_url].empty?
           logger.debug '[+] Login failed, please try again'
           return
         end

--- a/lib/poke-api/client.rb
+++ b/lib/poke-api/client.rb
@@ -76,7 +76,7 @@ module Poke
 
         resp = call.response
 
-        if !resp[:api_url] && resp[:api_url].empty?
+        if !resp[:api_url] || resp[:api_url].empty?
           logger.debug '[+] Login failed, please try again'
           return
         end


### PR DESCRIPTION
empty strings don't return false, endpoint got set to `https:///rpc` still
