### PR TITLE
Fix: require Fiddle missing

### DIFF
--- a/lib/poke-api/signature.rb
+++ b/lib/poke-api/signature.rb
@@ -1,3 +1,6 @@
+require "fiddle"
+require "fiddle/import"
+
 module Poke
   module API
     module Signature


### PR DESCRIPTION
`/var/lib/gems/2.3.0/gems/poke-go-api-0.1.1/lib/poke-api/signature.rb:4:in`module:Signature': uninitialized constant Poke::API::Signature::Fiddle (NameError)`
